### PR TITLE
Update readme stars workflow

### DIFF
--- a/.github/workflows/readme-stars.yml
+++ b/.github/workflows/readme-stars.yml
@@ -1,24 +1,27 @@
 name: Update readme ⭐️ progress
 
 on:
-    # !Please set a different minute than 51 if you enable this!
-    # schedule:
-    #     - cron: "51 */6 * * *" # Every 6 hours
-    workflow_dispatch:
+  push:
+    branches:
+      - main
+  # !Please set a different minute than 51 if you enable this!
+  # schedule:
+  #     - cron: "51 */6 * * *" # Every 6 hours
+  workflow_dispatch:
 
 jobs:
-    update-readme:
-        runs-on: ubuntu-latest
-        if: ${{ vars.AOC_ENABLED == 'true' }}
-        permissions:
-            contents: write
-        steps:
-            - uses: actions/checkout@v4
-            - uses: k2bd/advent-readme-stars@v1
-              with:
-                  userId: ${{ secrets.AOC_USER_ID }}
-                  sessionCookie: ${{ secrets.AOC_SESSION }}
-                  year: ${{ secrets.AOC_YEAR }}
-            - uses: stefanzweifel/git-auto-commit-action@v5
-              with:
-                  commit_message: "update readme progress"
+  update-readme:
+    runs-on: ubuntu-latest
+    if: ${{ vars.AOC_ENABLED == 'true' }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: k2bd/advent-readme-stars@v1
+        with:
+          userId: ${{ secrets.AOC_USER_ID }}
+          sessionCookie: ${{ secrets.AOC_SESSION }}
+          year: ${{ secrets.AOC_YEAR }}
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "update readme progress"


### PR DESCRIPTION
In order to enable this workflow to run on merges to the main branch, this commit adds an on push trigger specifically for main.